### PR TITLE
Release Drafter change-template, PR number

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,12 +18,7 @@ categories:
     labels:
       - 'documentation'
 
-change-template: |
-  <details>
-    <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
-
-    $BODY
-  </details>
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 
@@ -40,7 +35,7 @@ version-resolver:
       - 'bug'
       - 'packages'
       - 'documentation'
-  default: minor
+  default: patch
 
 template: |
   $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,7 @@ categories:
     labels:
       - 'documentation'
 
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-template: '- $TITLE @$AUTHOR ([#$NUMBER]($URL))'
 
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 

--- a/workflow-templates/release-drafter.yml
+++ b/workflow-templates/release-drafter.yml
@@ -5,7 +5,7 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches: [$default-branch]
   # pull_request event is required only for autolabeler
-  pull_request:
+  merge_group:
     # Only following types are handled by the action, but one can default to all as well
     types: [closed]
 

--- a/workflow-templates/release-drafter.yml
+++ b/workflow-templates/release-drafter.yml
@@ -7,9 +7,6 @@ on:
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
-
-  issues:
     types: [closed]
 
 permissions:

--- a/workflow-templates/release-drafter.yml
+++ b/workflow-templates/release-drafter.yml
@@ -2,12 +2,8 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
+    # branches to consider in the event: the default branch for each repo, currently 'main'.
     branches: [$default-branch]
-  # pull_request event is required only for autolabeler
-  merge_group:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [closed]
 
 permissions:
   contents: read


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #7.

**How did you implement your changes**

Changed the template of the release drafter to not include descriptions of merged PRs. Fixed the PR number/url issue. Release Drafter only runs when a PR is pushed to main.

**Remaining issues**

 None ATM.